### PR TITLE
fix getting ssl

### DIFF
--- a/subs_counter_v_2.0/subs_counter_v_2.0.ino
+++ b/subs_counter_v_2.0/subs_counter_v_2.0.ino
@@ -95,7 +95,7 @@ void getSSL_fp() {
     i = 0;
     httpCode = 0;
     payload = "";
-    http.begin("http://alexgyver.ru/get_SSL_fp.php");
+    http.begin("http://old.alexgyver.ru/get_SSL_fp.php");
     httpCode = http.GET();
     if (httpCode > 0) {
       payload = http.getString();


### PR DESCRIPTION
Похоже, что эндпоинт http://alexgyver.ru/get_SSL_fp.php больше не работает после переезда на новую версию сайта. Нужно или перенести скрипт, или использовать old.alexgyver.ru , что я и реализовал в своем pr. Please review.